### PR TITLE
FMI2: Parse type and unit definitions into `modelDescription`

### DIFF
--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -1179,10 +1179,15 @@ function fmi2GetUnit(mv::fmi2ScalarVariable)
 end
 
 """
+
    fmi2GetUnit(md::fmi2ModelDescription, mv::fmi2ScalarVariable)
 
 Returns the `unit` of the corresponding model variable `mv` as a `fmi2Unit` if it is
 defined in `md.unitDefinitions`.
+
+# Arguments
+- `md::fmi2ModelDescription`: Struct which provides the static information of ModelVariables.
+- `mv::fmi2ScalarVariable`: The “ModelVariables” element consists of an ordered set of “ScalarVariable” elements. A “ScalarVariable” represents a variable of primitive type, like a real or integer variable.
 
 # Source
 - FMISpec2.0.2 Link: [https://fmi-standard.org/](https://fmi-standard.org/)

--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -1155,6 +1155,27 @@ end
 
 """
 
+   fmi2GetUnit(md::fmi2ModelDescription, mv::fmi2ScalarVariable)
+
+Returns the `unit` of the corresponding model variable `mv` as a `fmi2Unit` if it is
+defined in `md.unitDefinitions`.
+
+# Source
+- FMISpec2.0.2 Link: [https://fmi-standard.org/](https://fmi-standard.org/)
+- FMISpec2.0.2: 2.2.7  Definition of Model Variables (ModelVariables)
+"""
+function fmi2GetUnit(md::fmi2ModelDescription, mv::fmi2ScalarVariable)
+    unit_str = fmi2GetUnit(mv)
+    if !isnothing(unit_str)
+        ui = findfirst(unit -> unit.name == unit_str, md.unitDefinitions)
+        if !isnothing(ui)
+            return md.unitDefinitions[ui]
+        end
+    end
+    return nothing
+end
+"""
+
    fmi2GetInitial(mv::fmi2ScalarVariable)
 
 Returns the `inital` entry of the corresponding model variable.

--- a/src/FMI2/md.jl
+++ b/src/FMI2/md.jl
@@ -219,7 +219,7 @@ function parseModelDescriptionVariable(defnode, _typename=nothing)
     elseif typename == "Boolean"
         typenode = fmi2ModelDescriptionBoolean()
         if haskey(defnode, "start")
-            targetArray[index].Boolean.start = parseFMI2Boolean(defnode["start"])
+            typenode.start = parseFMI2Boolean(defnode["start"])
         end
         # ToDo: remaining attributes
     elseif typename == "Integer"

--- a/src/FMI2/md.jl
+++ b/src/FMI2/md.jl
@@ -225,7 +225,7 @@ function parseModelDescriptionVariable(defnode, _typename=nothing)
     elseif typename == "Integer"
         typenode = fmi2ModelDescriptionInteger()
         if haskey(defnode, "start")
-            targetArray[index].Integer.start = parseInteger(defnode["start"])
+            typenode.start = parseInteger(defnode["start"])
         end
         # ToDo: remaining attributes
     elseif typename == "Enumeration"

--- a/src/FMI2/md.jl
+++ b/src/FMI2/md.jl
@@ -213,7 +213,7 @@ function parseModelDescriptionVariable(defnode, _typename=nothing)
     elseif typename == "String"
         typenode = fmi2ModelDescriptionString()
         if haskey(defnode, "start")
-            targetArray[index].String.start = defnode["start"]
+            typenode.start = defnode["start"]
         end
         # ToDo: remaining attributes
     elseif typename == "Boolean"


### PR DESCRIPTION
Based on the changes in https://github.com/ThummeTo/FMICore.jl/pull/33, this pull request modifies parsing of a model definition such that the `modelDescription` of an `FMU2` actually holds non-trivial `typeDefinitons` and `unitDefinitions` if present.

There is also post-processing for the model variables to set the attributes according to a `declaredType` if applicable, i.e., if an attribute is not defined for the model variable but for the relevant SimpleType.

Lastly, there is a convenience function `fmi2GetUnit(model_description, model_variable)` to retrieve the unit corresponding to `model_variable.Real.unit` from `model_description.unitDefinitions`.

Marked as “draft” because:
* I am really new to this whole thing,
* the docs should be adapted,
* maybe these changes should be tested (automatically).