### PR TITLE
Accomodate property methods for `fmi2SimpleType`.

### DIFF
--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -1178,9 +1178,20 @@ function fmi2GetUnit(mv::fmi2ScalarVariable)
     end
 end
 
-function fmi2GetUnit(mv::fmi2SimpleType)
-    if !isnothing(mv.type)
-        return mv.type.unit
+"""
+
+    fmi2GetUnit(st::fmi2SimpleType)
+
+Returns the `unit` entry (a string) of the corresponding simple type `st` if it has the 
+attribute `Real` and `nothing` otherwise.
+
+# Source
+- FMISpec2.0.3 Link: [https://fmi-standard.org/](https://fmi-standard.org/)
+- FMISpec2.0.3: 2.2.3 Definition of Types (TypeDefinitions)
+"""
+function fmi2GetUnit(st::fmi2SimpleType)
+    if hasproperty(st, :Real)
+        return st.Real.unit
     else
         nothing
     end
@@ -1245,13 +1256,14 @@ function fmi2GetDeclaredType(md::fmi2ModelDescription, mv::fmi2ScalarVariable)
     return nothing
 end
 
+# TODO with the new `fmi2SimpleType` definition this function is superfluous...remove?
 """
 
    fmi2GetSimpleTypeAttributeStruct(st::fmi2SimpleType)
 
 Returns the attribute structure for the simple type `st`.
 Depending on definition, this is either `st.Real`, `st.Integer`, `st.String`, 
-`st.Boolean` or `st.Enumeration`, whichever is not `nothing`.
+`st.Boolean` or `st.Enumeration`.
 
 # Arguments
 - `st::fmi2SimpleType`: Struct which provides the information on custom SimpleTypes.
@@ -1261,8 +1273,7 @@ Depending on definition, this is either `st.Real`, `st.Integer`, `st.String`,
 - FMISpec2.0.3[p.40]: 2.2.3 Definition of Types (TypeDefinitions)
 """
 function fmi2GetSimpleTypeAttributeStruct(st::fmi2SimpleType)
-    !isnothing(st.type) && return st.type
-    return nothing 
+    return getfield(st, :type)
 end
 
 """

--- a/src/FMI2/md.jl
+++ b/src/FMI2/md.jl
@@ -391,7 +391,7 @@ end
     setDefaultsWithSimpleType!(variable_description, simple_type)
 
 Helper function to set the attributes of `variable description` according to the attributes 
-stored in `simple_type`.
+stored in `simple_type`. However, if a value is set already, it is not overwritten.
 """
 setDefaultsWithSimpleType!(variable_description, simple_type)=nothing
 # helper to avoid redundant code below:
@@ -409,15 +409,13 @@ end
 # Helper function to set the attributes of `variable description` according to the attributes 
 # stored in `simple_type`, for **Real** variables:
 function setDefaultsWithSimpleType!(variable_description::FMICore.fmi2ModelDescriptionReal, simple_type)
-    attr_struct = simple_type.type
-    @assert typeof(attr_struct) == FMICore.fmi2SimpleTypeAttributesReal
+    attr_struct = simple_type.Real # throws error if `simple_type` has no attribute `Real`
     return setDefaultsWithSimpleType!(attr_struct, variable_description)
 end
 # Helper function to set the attributes of `variable description` according to the attributes 
 # stored in `simple_type`, for **Integer** variables:
 function setDefaultsWithSimpleType!(variable_description::FMICore.fmi2ModelDescriptionInteger, simple_type)
-    attr_struct = simple_type.type
-    @assert typeof(attr_struct) == FMICore.fmi2SimpleTypeAttributesInteger
+    attr_struct = simple_type.Integer
     return setDefaultsWithSimpleType!(attr_struct, variable_description)
 end
 

--- a/test/FMI2/model_description.jl
+++ b/test/FMI2/model_description.jl
@@ -85,7 +85,7 @@ dict = fmi2GetInputNamesAndStarts(myFMU)
 @test myFMU.modelDescription.unitDefinitions[5].name == "W"
 @test myFMU.modelDescription.unitDefinitions[6].baseUnit.kg == 1
 @test myFMU.modelDescription.typeDefinitions[1].name == "Modelica.Units.SI.Acceleration"
-stype_attr = myFMU.modelDescription.typeDefinitions[1].type
+stype_attr = myFMU.modelDescription.typeDefinitions[1].Real
 @test stype_attr.quantity == "Acceleration"
 @test stype_attr.unit == "m/s2"
 stype_unit = FMIImport.fmi2GetUnit(myFMU.modelDescription, myFMU.modelDescription.typeDefinitions[1]);


### PR DESCRIPTION
Reversal of some of the changes in #79 based on the changes in https://github.com/ThummeTo/FMICore.jl/pull/38.

With those property methods, we can again do `simpleType.Real`, for example.
`simpleType.type` still works, but `simpleType.Real` throws an AssertionError if the property is not right for `simpleType`.
Previously, the return value would have been `nothing`.

