### PR TITLE
Performance improvements

### DIFF
--- a/src/FMI2/c.jl
+++ b/src/FMI2/c.jl
@@ -1618,7 +1618,7 @@ function fmi2SetContinuousStates(c::FMU2Component,
 
     if track
         if status == fmi2StatusOK
-            c.x = copy(x)
+            isnothing(c.x) ? (c.x = x;) : copyto!(c.x, x)
 
             FMICore.invalidate!(c.A)
             FMICore.invalidate!(c.C)

--- a/src/FMI2/c.jl
+++ b/src/FMI2/c.jl
@@ -1626,7 +1626,7 @@ function fmi2SetContinuousStates(c::FMU2Component,
 
     if track
         if status == fmi2StatusOK
-            isnothing(c.x) ? (c.x = x;) : copyto!(c.x, x)
+            isnothing(c.x) ? (c.x = copy(x);) : copyto!(c.x, x)
 
             FMICore.invalidate!(c.A)
             FMICore.invalidate!(c.C)

--- a/src/FMI2/int.jl
+++ b/src/FMI2/int.jl
@@ -1185,15 +1185,12 @@ See also [`fmi2CompletedIntegratorStep`](@ref).
 """
 function fmi2CompletedIntegratorStep(c::FMU2Component,
                                         noSetFMUStatePriorToCurrentPoint::fmi2Boolean)
-    enterEventMode = zeros(fmi2Boolean, 1)
-    terminateSimulation = zeros(fmi2Boolean, 1)
-
     status = fmi2CompletedIntegratorStep!(c,
                                           noSetFMUStatePriorToCurrentPoint,
-                                          pointer(enterEventMode),
-                                          pointer(terminateSimulation))
+                                          c.ptr_stepEnterEventMode,
+                                          c.ptr_terminateSimulation)
 
-    return (status, enterEventMode[1], terminateSimulation[1])
+    return (status, c.stepEnterEventMode, c.terminateSimulation)
 end
 
 """

--- a/src/FMI2/int.jl
+++ b/src/FMI2/int.jl
@@ -227,15 +227,12 @@ More detailed:
 - FMISpec2.0.2[p.18]: 2.1.3 Status Returned by Functions
 See also [`fmi2SetReal`](@ref).
 """
-function fmi2SetReal(c::FMU2Component, vr::fmi2ValueReferenceFormat, values::Union{AbstractArray{<:Real}, <:Real}; kwargs...)
-
-    vr = prepareValueReference(c, vr)
-    values = prepareValue(values)
+function fmi2SetReal(c::FMU2Component, vr::fmi2ValueReferenceFormat, values::AbstractVector{fmi2Real}; kwargs...)
     @assert length(vr) == length(values) "fmi2SetReal(...): `vr` ($(length(vr))) and `values` ($(length(values))) need to be the same length."
-
     nvr = Csize_t(length(vr))
-    fmi2SetReal(c, vr, nvr, Array{fmi2Real}(values); kwargs...)
+    fmi2SetReal(c, prepareValueReference(c, vr), nvr, prepareValue(values); kwargs...)
 end
+fmi2SetReal(c::FMU2Component, vr::fmi2ValueReferenceFormat, values::Real; kwargs...) = fmi2SetReal(c, prepareValueReference(c, vr), prepareValue(values); kwargs...)
 
 """
     fmi2GetInteger(c::FMU2Component, vr::fmi2ValueReferenceFormat)
@@ -1118,14 +1115,15 @@ More detailed:
 - FMISpec2.0.2[p.83]: 3.2.1 Providing Independent Variables and Re-initialization of Caching
 See also [`fmi2SetContinuousStates`](@ref).
 """
-function fmi2SetContinuousStates(c::FMU2Component, x::Union{AbstractArray{Float32}, AbstractArray{Float64}}; kwargs...)
+function fmi2SetContinuousStates(c::FMU2Component, x::AbstractArray{fmi2Real}; kwargs...)
     nx = Csize_t(length(x))
-    status = fmi2SetContinuousStates(c, Array{fmi2Real}(x), nx; kwargs...)
+    status = fmi2SetContinuousStates(c, x, nx; kwargs...)
     if status == fmi2StatusOK
         c.x = x
     end
     return status
 end
+fmi2SetContinuousStates(c::FMU2Component, x::AbstractArray{Float32}; kwargs...) = fmi2SetContinuousStates(c, Array{fmi2Real}(x); kwargs...)
 
 """
     fmi2NewDiscreteStates(c::FMU2Component)

--- a/src/FMI2/int.jl
+++ b/src/FMI2/int.jl
@@ -1119,7 +1119,7 @@ function fmi2SetContinuousStates(c::FMU2Component, x::AbstractArray{fmi2Real}; k
     nx = Csize_t(length(x))
     status = fmi2SetContinuousStates(c, x, nx; kwargs...)
     if status == fmi2StatusOK
-        c.x = x
+        isnothing(c.x) ? (c.x = copy(x);) : copyto!(c.x, x)
     end
     return status
 end

--- a/src/FMI2/sens.jl
+++ b/src/FMI2/sens.jl
@@ -190,24 +190,21 @@ function eval!(cRef::UInt64,
     @assert (!isdual(t) && !istracked(t)) "eval!(...): Wrong dispatched: `t` is ForwardDiff.Dual/ReverseDiff.TrackedReal, please open an issue with MWE."
     @assert (!isdual(p) && !istracked(p)) "eval!(...): Wrong dispatched: `p` is ForwardDiff.Dual/ReverseDiff.TrackedReal, please open an issue with MWE."
 
-    x = unsense(x)
-    t = unsense(t)
-    u = unsense(u)
     # p = unsense(p)     # no need to unsense `p` because it is not beeing used further
 
     # set state
     if length(x) > 0 && !c.fmu.isZeroState
-        fmi2SetContinuousStates(c, x)
+        fmi2SetContinuousStates(c, unsense(x))
     end
 
     # set time
     if t >= 0.0
-        fmi2SetTime(c, t)
+        fmi2SetTime(c, unsense(t))
     end
 
     # set input
     if length(u) > 0 
-        fmi2SetReal(c, u_refs, u)
+        fmi2SetReal(c, u_refs, unsense(u))
     end
 
     # get derivative

--- a/src/FMI2/sens.jl
+++ b/src/FMI2/sens.jl
@@ -69,15 +69,15 @@ Not all options are available for any FMU type, e.g. setting state is not suppor
 - `y::Union{AbstractVector{<:Real}, Nothing}`: The system output `y` (if requested, otherwise `nothing`).
 - `dx::Union{AbstractVector{<:Real}, Nothing}`: The system state-derivaitve (if ME-FMU, otherwise `nothing`).
 """
-function (fmu::FMU2)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
-    y::AbstractVector{<:Real}=Vector{fmi2Real}(),
-    y_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
-    x::AbstractVector{<:Real}=Vector{fmi2Real}(), 
-    u::AbstractVector{<:Real}=Vector{fmi2Real}(),
-    u_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
-    p::AbstractVector{<:Real}=fmu.optim_p, 
-    p_refs::AbstractVector{<:fmi2ValueReference}=fmu.optim_p_refs, 
-    t::Real=-1.0)
+function (fmu::FMU2)(dx::AbstractVector{<:Real},
+    y::AbstractVector{<:Real},
+    y_refs::AbstractVector{<:fmi2ValueReference},
+    x::AbstractVector{<:Real},
+    u::AbstractVector{<:Real},
+    u_refs::AbstractVector{<:fmi2ValueReference},
+    p::AbstractVector{<:Real},
+    p_refs::AbstractVector{<:fmi2ValueReference},
+    t::Real)
 
     if hasCurrentComponent(fmu)
         c = getCurrentComponent(fmu)
@@ -93,6 +93,18 @@ function (fmu::FMU2)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
     end
 
     c(;dx=dx, y=y, y_refs=y_refs, x=x, u=u, u_refs=u_refs, p=p, p_refs=p_refs, t=t)
+end
+
+function (fmu::FMU2)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
+    y::AbstractVector{<:Real}=Vector{fmi2Real}(),
+    y_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
+    x::AbstractVector{<:Real}=Vector{fmi2Real}(), 
+    u::AbstractVector{<:Real}=Vector{fmi2Real}(),
+    u_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
+    p::AbstractVector{<:Real}=fmu.optim_p, 
+    p_refs::AbstractVector{<:fmi2ValueReference}=fmu.optim_p_refs, 
+    t::Real=-1.0)
+    (fmu)(dx, y, y_refs, x, u, u_refs, p, p_refs, t)
 end
 
 """
@@ -123,15 +135,16 @@ Not all options are available for any FMU type, e.g. setting state is not suppor
 - `y::Union{AbstractVector{<:Real}, Nothing}`: The system output `y` (if requested, otherwise `nothing`).
 - `dx::Union{AbstractVector{<:Real}, Nothing}`: The system state-derivaitve (if ME-FMU, otherwise `nothing`).
 """
-function (c::FMU2Component)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
-                             y::AbstractVector{<:Real}=Vector{fmi2Real}(),
-                             y_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
-                             x::AbstractVector{<:Real}=Vector{fmi2Real}(), 
-                             u::AbstractVector{<:Real}=Vector{fmi2Real}(),
-                             u_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
-                             p::AbstractVector{<:Real}=c.fmu.optim_p, 
-                             p_refs::AbstractVector{<:fmi2ValueReference}=c.fmu.optim_p_refs, 
-                             t::Real=c.next_t)
+function (c::FMU2Component)(dx::AbstractVector{<:Real},
+                            y::AbstractVector{<:Real},
+                            y_refs::AbstractVector{<:fmi2ValueReference},
+                            x::AbstractVector{<:Real},
+                            u::AbstractVector{<:Real},
+                            u_refs::AbstractVector{<:fmi2ValueReference},
+                            p::AbstractVector{<:Real},
+                            p_refs::AbstractVector{<:fmi2ValueReference},
+                            t::Real)
+
 
     if length(y_refs) > 0
         if length(y) <= 0 
@@ -168,6 +181,18 @@ function (c::FMU2Component)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
     end
 
     return eval!(cRef, dx, y, y_refs, x, u, u_refs, p, p_refs, t)
+end
+
+function (c::FMU2Component)(;dx::AbstractVector{<:Real}=Vector{fmi2Real}(),
+                             y::AbstractVector{<:Real}=Vector{fmi2Real}(),
+                             y_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
+                             x::AbstractVector{<:Real}=Vector{fmi2Real}(), 
+                             u::AbstractVector{<:Real}=Vector{fmi2Real}(),
+                             u_refs::AbstractVector{<:fmi2ValueReference}=Vector{fmi2ValueReference}(),
+                             p::AbstractVector{<:Real}=c.fmu.optim_p, 
+                             p_refs::AbstractVector{<:fmi2ValueReference}=c.fmu.optim_p_refs, 
+                             t::Real=c.next_t)
+    (c)(dx, y, y_refs, x, u, u_refs, p, p_refs, t)
 end
 
 function eval!(cRef::UInt64, 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -159,7 +159,10 @@ end
 
 # makes Reals from ForwardDiff/ReverseDiff.TrackedXXX scalar/vector
 function unsense(e::AbstractArray)
-    return collect(unsense(c) for c in e)
+    return unsense.(e)
+end
+function unsense(e::AbstractArray{fmi2Real})
+    return e
 end
 function unsense(e::Tuple)
     return (collect(unsense(c) for c in e)...,)


### PR DESCRIPTION
Hi, I was profiling my code and noticed that most of the time was spent inside FMIImport.jl, so I decided to make some performance improvements. Functionality-wise there is no change. The example I was testing this on went from about 60s with 22 GB allocations to 18s with 2.8 GB (which is still not amazing in all honesty).

This is only for FMI2 as I don't use FMI3 myself. Some of these changes require updates to [FMICore.jl](https://github.com/ThummeTo/FMICore.jl) which is incoming. Before merging, FMICore.jl shoud thus be updated and the `Project.toml` in this repo should be updated for compatibility.

# Summary
- `fmi2SetReal` checking of the Jacobians in `c.jl` has been improved (biggest performance gain by far). By making a `Set` of $\partial$`f_refs`, it is possible to do lookups in O(1) instead of O(n), which reduces the for loop runtime complexity.
- Various allocations and copies have been removed if possible
- Type stability has been improved where possible
- Added methods to keyword-only performance-critical functions `(fmu::FMU2)` and `(c::FMU2Component)` which seem to be faster.

# Performance tips from a user perspective
The FMI C-functions (e.g. `cFmi2SetReal`...) operate on `Vector{T}` and return this type, regardless of which type of array was provided (where `T` depends on the C-function). If other types `::AbstractVector{<:Real}` are provided, they are converted upon every C-call which takes a lot of time and memory allocations. @ThummeTo Maybe it would be a good idea to dispatch functions instead on `Vector{T}` and have a single catch-all upper method dispatch on `AbstractVector{<:Real}` and provide a performance warning for every function?

For optimal performance it is best to preallocate a `v::Vector{T}` of the correct size and type and reuse this as an intermediate buffer between whatever function you have running and the FMU. (I was personally passing views of arrays to avoid allocation, but this turned out to be counterproductive because of above)

# Further improvements
The remaining allocations and slowness are mostly caused by type instability/ambiguity. This happens for example in the `FMU2Component` which has fields `A,B,C,D,E,F::Union{Nothing,FMUJacobian}` This means that in every function, Julia has to check at runtime what the type is, even though we know that functions like `fmi2SetReal` are only called when the Jacobians are already initialised. This causes significant slowdown. This would however require more significant changes to the library than I am personally willing to make (and would be too big for one PR).