### PR TITLE
Type stability for StringToValueReference

### DIFF
--- a/src/FMI2/convert.jl
+++ b/src/FMI2/convert.jl
@@ -134,7 +134,7 @@ Returns the ValueReference or an array of ValueReferences coresponding to the va
 See also [`fmi2StringToValueReference`](@ref)
 """
 function fmi2StringToValueReference(md::fmi2ModelDescription, name::String)
-    reference = nothing
+    reference = typemax(valtype(md.stringValueReferences))
     if haskey(md.stringValueReferences, name)
         reference = md.stringValueReferences[name]
     else


### PR DESCRIPTION
`fmi2StringToValueReference` has a type instability where it can return either a `UInt32` or a `Nothing` type result.
This gives some impracticalities when for example broadcasting where you can get either a `Vector{UInt32}` or a `Vector{Union{Nothing,UInt32}}` depending on the input. This pull-request fixes that by returning `typemax(UInt32)` (= 4.3e9) by default.
 (If your model has more than 4.3e9 inputs then this will fail, but I don't think this edge case is realistic)