### PR TITLE
Different (correct) handling of dependencies=""

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FMIImport"
 uuid = "9fcbc62e-52a0-44e9-a616-1359a0008194"
 authors = ["TT <tobias.thummerer@informatik.uni-augsburg.de>", "LM <lars.mikelsons@informatik.uni-augsburg.de>", "JK <josef.kircher@student.uni-augsburg.de>"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/src/FMI2/md.jl
+++ b/src/FMI2/md.jl
@@ -407,6 +407,8 @@ function parseUnknown(md::fmi2ModelDescription, node::EzXML.Node)
                 if length(dependenciesSplit) > 0
                     varDep.dependencies = collect(parse(UInt, e) for e in dependenciesSplit)
                 end
+            else 
+                varDep.dependencies = UInt[]
             end
         end
 
@@ -419,6 +421,8 @@ function parseUnknown(md::fmi2ModelDescription, node::EzXML.Node)
                         stringToDependencyKind(md, e) for e in dependenciesKindSplit
                     )
                 end
+            else 
+                varDep.dependenciesKind = fmi2DependencyKind[]
             end
         end
 

--- a/src/FMI3/md.jl
+++ b/src/FMI3/md.jl
@@ -464,6 +464,8 @@ function parseDependencies(md::fmi3ModelDescription, node::EzXML.Node)
             if length(dependenciesSplit) > 0
                 varDep.dependencies = collect(parse(UInt, e) for e in dependenciesSplit)
             end
+        else 
+            varDep.dependencies = UInt[]
         end
     end
 
@@ -475,6 +477,8 @@ function parseDependencies(md::fmi3ModelDescription, node::EzXML.Node)
                 varDep.dependenciesKind =
                     collect(stringToDependencyKind(md, e) for e in dependenciesKindSplit)
             end
+        else 
+            varDep.dependenciesKind = fmi3DependencyKind[]
         end
     end
 

--- a/test/FMI2/model_description.jl
+++ b/test/FMI2/model_description.jl
@@ -134,3 +134,17 @@ for sv in myFMU.modelDescription.modelVariables
 end
 
 unloadFMU(myFMU)
+
+myFMU = loadFMU("BouncingBall", "ModelicaReferenceFMUs", "0.0.30", "2.0")
+@test isnothing(myFMU.modelDescription.modelStructure.derivatives[1].dependencies)
+
+info(myFMU) # check if there is an error thrown
+
+unloadFMU(myFMU)
+
+myFMU = loadFMU("Dahlquist", "ModelicaReferenceFMUs", "0.0.30", "2.0")
+@test !isnothing(myFMU.modelDescription.modelStructure.outputs[1].dependencies)
+
+info(myFMU) # check if there is an error thrown
+
+unloadFMU(myFMU)

--- a/test/FMI3/model_description.jl
+++ b/test/FMI3/model_description.jl
@@ -34,7 +34,17 @@ myFMU = loadFMU("BouncingBall", "ModelicaReferenceFMUs", "0.0.30", "3.0")
 @test myFMU.modelDescription.eventIndicatorValueReferences == [1]
 @test typeof(myFMU.modelDescription.modelStructure.eventIndicators[1]) == fmi3VariableDependency
 
+@test isnothing(myFMU.modelDescription.modelStructure.continuousStateDerivatives[1].dependencies)
+
 
 info(myFMU) # check if there is an error thrown
 
 unloadFMU(myFMU)
+
+# Sadly there are no FMI3-Reference-FMUs with dependencies=""
+# myFMU = loadFMU("Dahlquist", "ModelicaReferenceFMUs", "0.0.30", "3.0")
+# @test !isnothing(myFMU.modelDescription.modelStructure.outputs[1].dependencies)
+
+# info(myFMU) # check if there is an error thrown
+
+# unloadFMU(myFMU)


### PR DESCRIPTION
The standard specifies different behaviour for `dependencies=""` and the `dependencies`-Tag not being present at all:

```
If dependencies is not present, it must be assumed that the unknown depends on all knowns. If dependencies is present as empty list, the unknown depends on none of the knowns. Otherwise the unknown depends on the knowns defined by the given value references.
```
(from FMI3-Standard)

Currently we handle the first and second case identically with `modelDescription.modelStructure.continuousStateDerivatives[n].dependencies = nothing`. This leads to some very pessimistic handling of dependency-information in the second case. We basically have to assume that every variable that actually depends on nothing depends on everything instead. If a FMU has even one of those, we dont gain any performance from using Sparsity-Information.

I propose to leave the first case as it is (`modelStructure.continuousStateDerivatives[n].dependencies = nothing`) and using an empty array for the second case (`modelStructure.continuousStateDerivatives[n].dependencies = UInt[]`). This makes it possible to differentiate the two cases while adding minimal overhead (1 pointer/allocation per empty `dependencies` and they are not that common as far as i can tell).

This PR contains the behaviour described above, as well as Tests for it. 

Note that there are currently no FMI3-Reference-FMUs with `dependencies=""`, so there is currently no Test for this case. I submitted an upstream-Issue: https://github.com/modelica/Reference-FMUs/issues/597#issue-2559398283
