### PR TITLE
add dependencies="" FMI3 Test

### DIFF
--- a/test/FMI3/model_description.jl
+++ b/test/FMI3/model_description.jl
@@ -41,10 +41,9 @@ info(myFMU) # check if there is an error thrown
 
 unloadFMU(myFMU)
 
-# Sadly there are no FMI3-Reference-FMUs with dependencies=""
-# myFMU = loadFMU("Dahlquist", "ModelicaReferenceFMUs", "0.0.30", "3.0")
-# @test !isnothing(myFMU.modelDescription.modelStructure.outputs[1].dependencies)
+myFMU = loadFMU("Dahlquist", "ModelicaReferenceFMUs", "0.0.36", "3.0")
+@test !isnothing(myFMU.modelDescription.modelStructure.outputs[1].dependencies)
 
-# info(myFMU) # check if there is an error thrown
+info(myFMU) # check if there is an error thrown
 
-# unloadFMU(myFMU)
+unloadFMU(myFMU)


### PR DESCRIPTION
There was a missing Test case because of a problem in the ReferenceFMUs. This was fixed in  https://github.com/modelica/Reference-FMUs/pull/605, so this PR adds the missing Test.
