### PR TITLE
Add aarch64-darwin to macOS binary directory search

### DIFF
--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -123,8 +123,13 @@ function createFMU2(
         fmuExt = "so"
     elseif Sys.isapple()
         if juliaArch == 64
-            directories =
-                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "aarch64-darwin")]
+            if Sys.ARCH === :aarch64
+                directories =
+                    [joinpath("binaries", "aarch64-darwin")]
+            else
+                directories =
+                    [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]
+            end
         else
             directories = []
         end

--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -124,7 +124,7 @@ function createFMU2(
     elseif Sys.isapple()
         if juliaArch == 64
             directories =
-                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]
+                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "aarch64-darwin")]
         else
             directories = []
         end

--- a/src/FMI3/ext.jl
+++ b/src/FMI3/ext.jl
@@ -103,8 +103,13 @@ function createFMU3(fmuPath, fmuZipPath; type::Union{Symbol,Nothing} = nothing)
         fmuExt = "so"
     elseif Sys.isapple()
         if juliaArch == 64
-            directories =
-                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "aarch64-darwin")]
+            if Sys.ARCH === :aarch64
+                directories =
+                    [joinpath("binaries", "aarch64-darwin")]
+            else
+                directories =
+                    [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]
+            end
         else
             directories = []
         end

--- a/src/FMI3/ext.jl
+++ b/src/FMI3/ext.jl
@@ -104,7 +104,7 @@ function createFMU3(fmuPath, fmuZipPath; type::Union{Symbol,Nothing} = nothing)
     elseif Sys.isapple()
         if juliaArch == 64
             directories =
-                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]
+                [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "aarch64-darwin")]
         else
             directories = []
         end


### PR DESCRIPTION
## Summary
- On Apple Silicon (M1/ARM) Macs, the Reference FMUs build system produces binaries in `binaries/aarch64-darwin/`, but FMIImport only searched `darwin64/` and `x86_64-darwin/`
- Adds an `Sys.ARCH` check on macOS: on `aarch64`, only `aarch64-darwin` is searched; on `x86_64`, the existing `darwin64`/`x86_64-darwin` search is preserved
- Rosetta 2 is a whole-program feature — an aarch64 Julia process cannot load an x86_64 dylib, so falling back to x86_64 directories on ARM would be incorrect

🤖 Generated with [Claude Code](https://claude.com/claude-code)