### PR TITLE
Restore darwin64 fallback for FMI 2.0 on aarch64-darwin

### DIFF
--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -125,7 +125,7 @@ function createFMU2(
         if juliaArch == 64
             if Sys.ARCH === :aarch64
                 directories =
-                    [joinpath("binaries", "aarch64-darwin")]
+                    [joinpath("binaries", "aarch64-darwin"), joinpath("binaries", "darwin64")]
             else
                 directories =
                     [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]

--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -27,8 +27,8 @@ Retrieves all the pointers of binary functions.
 function createFMU2(
     fmuPath,
     fmuZipPath;
-    type::Union{Symbol,fmi2Type,Nothing}=nothing,
-    logLevel::Union{FMULogLevel,Symbol}=FMULogLevelWarn,
+    type::Union{Symbol,fmi2Type,Nothing} = nothing,
+    logLevel::Union{FMULogLevel,Symbol} = FMULogLevelWarn,
 )
     # Create uninitialized FMU
 
@@ -89,7 +89,7 @@ function createFMU2(
         end
     end
 
-    fmuName = getModelIdentifier(fmu.modelDescription; type=fmu.type) # tmpName[length(tmpName)]
+    fmuName = getModelIdentifier(fmu.modelDescription; type = fmu.type) # tmpName[length(tmpName)]
 
     directoryBinary = ""
     pathToBinary = ""
@@ -124,11 +124,15 @@ function createFMU2(
     elseif Sys.isapple()
         if juliaArch == 64
             if Sys.ARCH === :aarch64
-                directories =
-                    [joinpath("binaries", "aarch64-darwin"), joinpath("binaries", "darwin64")]
+                directories = [
+                    joinpath("binaries", "aarch64-darwin"),
+                    joinpath("binaries", "darwin64"),
+                ]
             else
-                directories =
-                    [joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "darwin64")]
+                directories = [
+                    joinpath("binaries", "x86_64-darwin"),
+                    joinpath("binaries", "darwin64"),
+                ]
             end
         else
             directories = []

--- a/src/FMI2/ext.jl
+++ b/src/FMI2/ext.jl
@@ -128,7 +128,7 @@ function createFMU2(
                     [joinpath("binaries", "aarch64-darwin"), joinpath("binaries", "darwin64")]
             else
                 directories =
-                    [joinpath("binaries", "darwin64"), joinpath("binaries", "x86_64-darwin")]
+                    [joinpath("binaries", "x86_64-darwin"), joinpath("binaries", "darwin64")]
             end
         else
             directories = []


### PR DESCRIPTION
So in #144 I disallowed the `darwin64` directory for macOS aarch64 FMUs, but it turns out that some FMI2 producers still use darwin64 on macos.  FMPy seems to read both so I figured it might be OK to add it back, but prefer `aarch64-darwin`.